### PR TITLE
DEV: Update post-stream detection following core change

### DIFF
--- a/javascripts/discourse/api-initializers/discourse-orgchart.js
+++ b/javascripts/discourse/api-initializers/discourse-orgchart.js
@@ -137,7 +137,8 @@ async function cookOrgChart(element) {
 export default apiInitializer("0.11.1", (api) => {
   api.decorateCookedElement(
     async (elem, helper) => {
-      const id = helper ? `post_${helper.getModel().id}` : "composer";
+      const post = helper?.getModel();
+      const id = post ? `post_${post.id}` : "composer";
       applyOrgChart(elem, id);
     },
     { id: "discourse-orgchart" }


### PR DESCRIPTION
The helper is now available in all decoration locations, so we should gate this logic on the presence of the post model instead.